### PR TITLE
airin: add 'externalip=' to config file

### DIFF
--- a/config/airin/airin.conf
+++ b/config/airin/airin.conf
@@ -9,6 +9,7 @@ staking=0
 gen=0
 maxconnections=256
 bind=XXX_IPV6_INT_BASE_XXX:XXX_NETWORK_BASE_TAG_XXX::XXX_NUM_XXY:XXX_MNODE_INBOUND_PORT_XXX
+externalip=XXX_IPV6_INT_BASE_XXX
 
 #############################
 # nodes we want to stick to


### PR DESCRIPTION
When configuring 4 AIRIN masternodes on an OVH VPS with multiple IPs, it failed until I added the "externalip" option to the configuration file. The first MN would be ENABLED but the other 3 would be in the following state:
**"Not capable masternode: Broadcasted IP doesn't match our external address. Make sure you issued a new broadcast if IP of this masternode changed recently."**
All 3 MNs would also show the IP address of the first MN, adding "externalip" fixed this.